### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 /.build
 /Packages
 /*.xcodeproj
-
-# generated files
-Sources/ParserCombinator/Operators+Sequential.swift

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ initial:
 
 clean:
 	rm -rf .build
+	rm -f $(SEQUENTIAL_OPERATORS_SWIFT_PATH)
+	rm -rf ParserCombinator.xcodeproj
 
 generate:
 	chmod +x $(SEQUENTIAL_OPERATORS_PATH)

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,8 @@ SEQUENTIAL_OPERATORS_PATH = ./Scripts/SequentialOperators.swift
 SEQUENTIAL_OPERATORS_SWIFT_PATH = ./Sources/ParserCombinator/Operators+Sequential.swift
 
 initial:
-	make generate
 	swift package update
-	swift package generate-xcodeproj
+	make generate
 
 clean:
 	rm -rf .build
@@ -17,6 +16,7 @@ clean:
 generate:
 	chmod +x $(SEQUENTIAL_OPERATORS_PATH)
 	swift $(SEQUENTIAL_OPERATORS_PATH) $(NUMBER_OF_SEQUENTIAL_OPERATORS) > $(SEQUENTIAL_OPERATORS_SWIFT_PATH)
+	swift package generate-xcodeproj --enable-code-coverage
 
 test:
 	swift build

--- a/ParserCombinator.podspec
+++ b/ParserCombinator.podspec
@@ -23,4 +23,8 @@ Parsing is a very common task, it does not always mean to parse source code or J
 
   s.source_files = 'Sources/ParserCombinator/*.swift'
 
+  s.prepare_command = <<-CMD
+    make initial
+  CMD
+
 end

--- a/Scripts/SequentialOperators.swift
+++ b/Scripts/SequentialOperators.swift
@@ -68,13 +68,14 @@ public func ~<Token, \(chars), \(next)>(lhs: Parser<Token, (\(chars))>, rhs: Par
     
     if i > 1 {
         string += """
-        public func ~<Token, \(chars), \(next)>(lhs: Parser<Token, \(next)>, rhs: Parser<Token, (\(chars))>) -> Parser<Token, (\(next), \(chars))> {
-            return Parser { tokens in
-                return lhs.parse(tokens).flatMap(f: { (r, rest) in
-                    return rhs.parse(rest).map(f: { result, t in (r, \(results)) })
-                })
-            }
-        }
+        
+public func ~<Token, \(chars), \(next)>(lhs: Parser<Token, \(next)>, rhs: Parser<Token, (\(chars))>) -> Parser<Token, (\(next), \(chars))> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, \(results)) })
+        })
+    }
+}
 """
     }
 }

--- a/Sources/ParserCombinator/Operators+Sequential.swift
+++ b/Sources/ParserCombinator/Operators+Sequential.swift
@@ -1,0 +1,172 @@
+// This file is generated via scripts/SequentialOperators.swift. Do not modify manually!
+
+public func >~<Token, A, B>(lhs: Parser<Token, A>, rhs: Parser<Token, B>) -> Parser<Token, B> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { _, rest in
+            return rhs.parse(rest)
+        })
+    }
+}
+
+public func <~<Token, A, B>(lhs: Parser<Token, B>, rhs: Parser<Token, A>) -> Parser<Token, B> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { result, rest in
+            return rhs.parse(rest).map(f: { _, _ in
+                return result
+            })
+        })
+    }
+}
+
+public func ~<Token, A, B>(lhs: Parser<Token, (A)>, rhs: Parser<Token, B>) -> Parser<Token, (A, B)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result, r) })
+        })
+    }
+}
+    
+
+public func ~<Token, A, B, C>(lhs: Parser<Token, (A, B)>, rhs: Parser<Token, C>) -> Parser<Token, (A, B, C)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C>(lhs: Parser<Token, C>, rhs: Parser<Token, (A, B)>) -> Parser<Token, (C, A, B)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1) })
+        })
+    }
+}
+
+public func ~<Token, A, B, C, D>(lhs: Parser<Token, (A, B, C)>, rhs: Parser<Token, D>) -> Parser<Token, (A, B, C, D)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, result.2, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C, D>(lhs: Parser<Token, D>, rhs: Parser<Token, (A, B, C)>) -> Parser<Token, (D, A, B, C)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1, result.2) })
+        })
+    }
+}
+
+public func ~<Token, A, B, C, D, E>(lhs: Parser<Token, (A, B, C, D)>, rhs: Parser<Token, E>) -> Parser<Token, (A, B, C, D, E)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, result.2, result.3, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C, D, E>(lhs: Parser<Token, E>, rhs: Parser<Token, (A, B, C, D)>) -> Parser<Token, (E, A, B, C, D)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1, result.2, result.3) })
+        })
+    }
+}
+
+public func ~<Token, A, B, C, D, E, F>(lhs: Parser<Token, (A, B, C, D, E)>, rhs: Parser<Token, F>) -> Parser<Token, (A, B, C, D, E, F)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, result.2, result.3, result.4, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C, D, E, F>(lhs: Parser<Token, F>, rhs: Parser<Token, (A, B, C, D, E)>) -> Parser<Token, (F, A, B, C, D, E)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1, result.2, result.3, result.4) })
+        })
+    }
+}
+
+public func ~<Token, A, B, C, D, E, F, G>(lhs: Parser<Token, (A, B, C, D, E, F)>, rhs: Parser<Token, G>) -> Parser<Token, (A, B, C, D, E, F, G)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, result.2, result.3, result.4, result.5, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C, D, E, F, G>(lhs: Parser<Token, G>, rhs: Parser<Token, (A, B, C, D, E, F)>) -> Parser<Token, (G, A, B, C, D, E, F)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1, result.2, result.3, result.4, result.5) })
+        })
+    }
+}
+
+public func ~<Token, A, B, C, D, E, F, G, H>(lhs: Parser<Token, (A, B, C, D, E, F, G)>, rhs: Parser<Token, H>) -> Parser<Token, (A, B, C, D, E, F, G, H)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, result.2, result.3, result.4, result.5, result.6, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C, D, E, F, G, H>(lhs: Parser<Token, H>, rhs: Parser<Token, (A, B, C, D, E, F, G)>) -> Parser<Token, (H, A, B, C, D, E, F, G)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1, result.2, result.3, result.4, result.5, result.6) })
+        })
+    }
+}
+
+public func ~<Token, A, B, C, D, E, F, G, H, I>(lhs: Parser<Token, (A, B, C, D, E, F, G, H)>, rhs: Parser<Token, I>) -> Parser<Token, (A, B, C, D, E, F, G, H, I)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, result.2, result.3, result.4, result.5, result.6, result.7, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C, D, E, F, G, H, I>(lhs: Parser<Token, I>, rhs: Parser<Token, (A, B, C, D, E, F, G, H)>) -> Parser<Token, (I, A, B, C, D, E, F, G, H)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1, result.2, result.3, result.4, result.5, result.6, result.7) })
+        })
+    }
+}
+
+public func ~<Token, A, B, C, D, E, F, G, H, I, J>(lhs: Parser<Token, (A, B, C, D, E, F, G, H, I)>, rhs: Parser<Token, J>) -> Parser<Token, (A, B, C, D, E, F, G, H, I, J)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, result.2, result.3, result.4, result.5, result.6, result.7, result.8, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C, D, E, F, G, H, I, J>(lhs: Parser<Token, J>, rhs: Parser<Token, (A, B, C, D, E, F, G, H, I)>) -> Parser<Token, (J, A, B, C, D, E, F, G, H, I)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1, result.2, result.3, result.4, result.5, result.6, result.7, result.8) })
+        })
+    }
+}
+
+public func ~<Token, A, B, C, D, E, F, G, H, I, J, K>(lhs: Parser<Token, (A, B, C, D, E, F, G, H, I, J)>, rhs: Parser<Token, K>) -> Parser<Token, (A, B, C, D, E, F, G, H, I, J, K)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (result, rest) in
+            return rhs.parse(rest).map(f: { r, t in (result.0, result.1, result.2, result.3, result.4, result.5, result.6, result.7, result.8, result.9, r) })
+        })
+    }
+}
+            
+public func ~<Token, A, B, C, D, E, F, G, H, I, J, K>(lhs: Parser<Token, K>, rhs: Parser<Token, (A, B, C, D, E, F, G, H, I, J)>) -> Parser<Token, (K, A, B, C, D, E, F, G, H, I, J)> {
+    return Parser { tokens in
+        return lhs.parse(tokens).flatMap(f: { (r, rest) in
+            return rhs.parse(rest).map(f: { result, t in (r, result.0, result.1, result.2, result.3, result.4, result.5, result.6, result.7, result.8, result.9) })
+        })
+    }
+}

--- a/Sources/ParserCombinator/Parser+Conjunction.swift
+++ b/Sources/ParserCombinator/Parser+Conjunction.swift
@@ -26,9 +26,9 @@ extension Parser {
     /// Concatenates the results of self + all given parsers.
     /// The first of all that succeedes will be used.
     ///
-    /// - Parameter others: an array of parsers to use as fallback
+    /// - Parameter others: a sequence of parsers to use as fallback
     /// - Returns: a parser that tries all concatenates parsers in order
-    public func or(_ others: @escaping @autoclosure () -> [Parser<T, R>]) -> Parser<T, R> {
+    public func or<S: Sequence>(_ others: @escaping @autoclosure () -> S) -> Parser<T, R> where S.Element == Parser<T, R> {
         return Parser { tokens in
             let result = self.parse(tokens)
             switch result {

--- a/Sources/ParserCombinator/Parser+Conjunction.swift
+++ b/Sources/ParserCombinator/Parser+Conjunction.swift
@@ -23,6 +23,28 @@ extension Parser {
         }
     }
     
+    /// Concatenates the results of self + all given parsers.
+    /// The first of all that succeedes will be used.
+    ///
+    /// - Parameter others: an array of parsers to use as fallback
+    /// - Returns: a parser that tries all concatenates parsers in order
+    public func or(_ others: @escaping @autoclosure () -> [Parser<T, R>]) -> Parser<T, R> {
+        return Parser { tokens in
+            let result = self.parse(tokens)
+            switch result {
+            case let .success(result, rest):
+                return .success(result: result, rest: rest)
+            case let .fail(err):
+                for parser in others() {
+                    if case let .success(result, rest) = parser.parse(tokens) {
+                        return .success(result: result, rest: rest)
+                    }
+                }
+                return .fail(err) // the first error will be returned
+            }
+        }
+    }
+    
     /// Discards the result of self and executes other afterwards on the rest.
     ///
     /// - Parameter other: another parser to execute afterwards

--- a/Sources/ParserCombinator/RegexParser.swift
+++ b/Sources/ParserCombinator/RegexParser.swift
@@ -12,21 +12,26 @@ public final class RegexParser: Parser<String, String> {
     public enum Error: ParseError {
         case doesNotMatch(pattern: String, input: String)
         case unimplemented
+        case invalidRegex(String)
         
         public var code: UInt64 {
             switch self {
             case .doesNotMatch(_): return 0
             case .unimplemented: return 1
+            case .invalidRegex(_): return 2
             }
         }
     }
     
     public let regex: String
     
-    public init(_ regex: String) throws {
+    public init(_ regex: String) {
         self.regex = regex
-        let nsRegex = try NSRegularExpression(pattern: regex, options: [])
+        let nsRegex = try? NSRegularExpression(pattern: regex, options: [])
         super.init { str in
+            guard let nsRegex = nsRegex else {
+                return .fail(Error.invalidRegex(regex))
+            }
             let matches = nsRegex.matches(in: str, options: [.anchored], range: NSRange(location: 0, length: str.count))
             guard let first = matches.first else {
                 return .fail(Error.doesNotMatch(pattern: regex, input: str))
@@ -43,7 +48,7 @@ public final class RegexParser: Parser<String, String> {
 extension String {
     
     public var r: RegexParser {
-        return try! RegexParser(self)
+        return RegexParser(self)
     }
     
 }

--- a/Sources/ParserCombinator/RegexParser.swift
+++ b/Sources/ParserCombinator/RegexParser.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-#if os(OSX)
 public final class RegexParser: Parser<String, String> {
     
     public enum Error: ParseError {
@@ -48,4 +47,3 @@ extension String {
     }
     
 }
-#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -17,5 +17,6 @@ XCTMain([
     testCase(Parser_ConjunctionTests.allTests),
     testCase(Operators_SequentialTests.allTests),
     testCase(ParserTests.allTests),
+    testCase(RegexParserTests.allTests),
     ])
 #endif

--- a/Tests/ParserCombinatorTests/ErrorsTests.swift
+++ b/Tests/ParserCombinatorTests/ErrorsTests.swift
@@ -22,10 +22,8 @@ class ErrorsTests: XCTestCase {
 
 #if os(Linux)
     extension ErrorsTests {
-        static var allTests : [(String, (ErrorsTests) -> () throws -> Void)] {
-            return [
-                ("test_code", test_code),
-            ]
-        }
+        static var allTests = [
+            ("test_code", test_code),
+        ]
     }
 #endif

--- a/Tests/ParserCombinatorTests/Operators+SequentialTests.swift
+++ b/Tests/ParserCombinatorTests/Operators+SequentialTests.swift
@@ -55,6 +55,30 @@ class Operators_SequentialTests: XCTestCase {
         XCTAssertEqual(try p4.parse("aaaa").unwrap(), "aaaa")
     }
     
+    func test_sequential_otherWayAround() throws {
+        let p = char("a") ~ (char("b") ~ (char("c") ~ (char("d") ~ (char("e") ~ (char("f") ~ (char("g") ~ (char("h") ~ (char("i") ~ (char("j") ~ char("k"))))))))))
+        let input = "abcdefghijk"
+        let res = p.parse(input)
+        let value = try res.unwrap()
+        XCTAssertEqual(value.0, "a")
+        XCTAssertEqual(value.1, "b")
+        XCTAssertEqual(value.2, "c")
+        XCTAssertEqual(value.3, "d")
+        XCTAssertEqual(value.4, "e")
+        XCTAssertEqual(value.5, "f")
+        XCTAssertEqual(value.6, "g")
+        XCTAssertEqual(value.7, "h")
+        XCTAssertEqual(value.8, "i")
+        XCTAssertEqual(value.9, "j")
+        XCTAssertEqual(value.10, "k")
+        
+        let p2 = char("a") <~ (char("b") ~ char("c") ~ char("d") ~ char("e") ~ char("f") ~ char("g") ~ char("h") ~ char("i") ~ char("j") ~ char("k"))
+        XCTAssertEqual(try p2.parse(input).unwrap(), "a")
+        
+        let p3 = (char("a") ~ char("b") ~ char("c") ~ char("d") ~ char("e") ~ char("f") ~ char("g") ~ char("h") ~ char("i") ~ char("j")) >~ char("k")
+        XCTAssertEqual(try p3.parse(input).unwrap(), "k")
+    }
+    
 }
 
 #if os(Linux)
@@ -64,6 +88,7 @@ class Operators_SequentialTests: XCTestCase {
                 ("test_sequential_success", test_sequential_success),
                 ("test_sequential_fail", test_sequential_fail),
                 ("test_sequential", test_sequential),
+                ("test_sequential_otherWayAround", test_sequential_otherWayAround),
             ]
         }
     }

--- a/Tests/ParserCombinatorTests/Operators+SequentialTests.swift
+++ b/Tests/ParserCombinatorTests/Operators+SequentialTests.swift
@@ -83,13 +83,11 @@ class Operators_SequentialTests: XCTestCase {
 
 #if os(Linux)
     extension Operators_SequentialTests {
-        static var allTests : [(String, (Operators_SequentialTests) -> () throws -> Void)] {
-            return [
-                ("test_sequential_success", test_sequential_success),
-                ("test_sequential_fail", test_sequential_fail),
-                ("test_sequential", test_sequential),
-                ("test_sequential_otherWayAround", test_sequential_otherWayAround),
-            ]
-        }
+        static var allTests = [
+            ("test_sequential_success", test_sequential_success),
+            ("test_sequential_fail", test_sequential_fail),
+            ("test_sequential", test_sequential),
+            ("test_sequential_otherWayAround", test_sequential_otherWayAround),
+        ]
     }
 #endif

--- a/Tests/ParserCombinatorTests/OperatorsTests.swift
+++ b/Tests/ParserCombinatorTests/OperatorsTests.swift
@@ -72,15 +72,13 @@ class OperatorsTests: XCTestCase {
 
 #if os(Linux)
     extension OperatorsTests {
-        static var allTests : [(String, (OperatorsTests) -> () throws -> Void)] {
-            return [
-                ("test_or_operator_first", test_or_operator_first),
-                ("test_or_operator_second", test_or_operator_second),
-                ("test_then_operator", test_then_operator),
-                ("test_map_operator", test_map_operator),
-                ("test_map_operator_precendence", test_map_operator_precendence),
-                ("test_fallback_operator", test_fallback_operator)
-            ]
-        }
+        static var allTests = [
+            ("test_or_operator_first", test_or_operator_first),
+            ("test_or_operator_second", test_or_operator_second),
+            ("test_then_operator", test_then_operator),
+            ("test_map_operator", test_map_operator),
+            ("test_map_operator_precendence", test_map_operator_precendence),
+            ("test_fallback_operator", test_fallback_operator)
+        ]
     }
 #endif

--- a/Tests/ParserCombinatorTests/ParseResultTests.swift
+++ b/Tests/ParserCombinatorTests/ParseResultTests.swift
@@ -133,21 +133,19 @@ class ParseResultTests: XCTestCase {
 
 #if os(Linux)
     extension ParseResultTests {
-        static var allTests : [(String, (ParseResultTests) -> () throws -> Void)] {
-            return [
-                ("test_map_success", test_map_success),
-                ("test_map_fail", test_map_fail),
-                ("test_flatMap_success", test_flatMap_success),
-                ("test_flatMap_fail", test_flatMap_fail),
-                ("test_equal", test_equal),
-                ("test_unwrap", test_unwrap),
-                ("test_rest", test_rest),
-                ("test_rest", test_rest),
-                ("test_error", test_error),
-                ("test_isSuccess", test_isSuccess),
-                ("test_isFail", test_isFail),
-                ("test_RawRepresentable_conformance", test_RawRepresentable_conformance),
-            ]
-        }
+        static var allTests = [
+            ("test_map_success", test_map_success),
+            ("test_map_fail", test_map_fail),
+            ("test_flatMap_success", test_flatMap_success),
+            ("test_flatMap_fail", test_flatMap_fail),
+            ("test_equal", test_equal),
+            ("test_unwrap", test_unwrap),
+            ("test_rest", test_rest),
+            ("test_rest", test_rest),
+            ("test_error", test_error),
+            ("test_isSuccess", test_isSuccess),
+            ("test_isFail", test_isFail),
+            ("test_RawRepresentable_conformance", test_RawRepresentable_conformance),
+        ]
     }
 #endif

--- a/Tests/ParserCombinatorTests/Parser+ConjunctionTests.swift
+++ b/Tests/ParserCombinatorTests/Parser+ConjunctionTests.swift
@@ -93,17 +93,15 @@ class Parser_ConjunctionTests: XCTestCase {
 
 #if os(Linux)
     extension Parser_ConjunctionTests {
-        static var allTests : [(String, (Parser_ConjunctionTests) -> () throws -> Void)] {
-            return [
-                ("test_or", test_or),
-                ("test_then", test_then),
-                ("test_fallback", test_fallback),
-                ("test_fallback_parser", test_fallback_parser),
-                ("test_rep", test_rep),
-                ("test_rep2", test_rep2),
-                ("test_rep_fail", test_rep_fail),
-                ("test_typeErased", test_typeErased),
-            ]
-        }
+        static var allTests = [
+            ("test_or", test_or),
+            ("test_then", test_then),
+            ("test_fallback", test_fallback),
+            ("test_fallback_parser", test_fallback_parser),
+            ("test_rep", test_rep),
+            ("test_rep2", test_rep2),
+            ("test_rep_fail", test_rep_fail),
+            ("test_typeErased", test_typeErased),
+        ]
     }
 #endif

--- a/Tests/ParserCombinatorTests/Parser+ConjunctionTests.swift
+++ b/Tests/ParserCombinatorTests/Parser+ConjunctionTests.swift
@@ -22,7 +22,7 @@ class Parser_ConjunctionTests: XCTestCase {
         XCTAssertTrue(res2 == .success(result: "a", rest: "b"))
     }
     
-    func test_or_array() throws {
+    func test_or_sequence() throws {
         let zero = string("0")
         let oneToNine = (1...9).map({string(String($0))})
         let p = zero.or(oneToNine) ^^ { Int($0)! }
@@ -110,7 +110,7 @@ class Parser_ConjunctionTests: XCTestCase {
     extension Parser_ConjunctionTests {
         static var allTests = [
             ("test_or", test_or),
-            ("test_or_array", test_or_array),
+            ("test_or_sequence", test_or_sequence),
             ("test_then", test_then),
             ("test_fallback", test_fallback),
             ("test_fallback_parser", test_fallback_parser),

--- a/Tests/ParserCombinatorTests/Parser+ConjunctionTests.swift
+++ b/Tests/ParserCombinatorTests/Parser+ConjunctionTests.swift
@@ -21,6 +21,21 @@ class Parser_ConjunctionTests: XCTestCase {
         let res2 = p2.parse("ab")
         XCTAssertTrue(res2 == .success(result: "a", rest: "b"))
     }
+    
+    func test_or_array() throws {
+        let zero = string("0")
+        let oneToNine = (1...9).map({string(String($0))})
+        let p = zero.or(oneToNine) ^^ { Int($0)! }
+        
+        let res1 = p.parse("0")
+        XCTAssertEqual(try res1.unwrap(), 0)
+        
+        let res2 = p.parse("3")
+        XCTAssertEqual(try res2.unwrap(), 3)
+        
+        let res3 = p.parse("a")
+        XCTAssertTrue(res3.isFailed())
+    }
 
     func test_then() {
         let p = char("a").then(char("b"))
@@ -95,6 +110,7 @@ class Parser_ConjunctionTests: XCTestCase {
     extension Parser_ConjunctionTests {
         static var allTests = [
             ("test_or", test_or),
+            ("test_or_array", test_or_array),
             ("test_then", test_then),
             ("test_fallback", test_fallback),
             ("test_fallback_parser", test_fallback_parser),

--- a/Tests/ParserCombinatorTests/ParserCombinator_TestCase.swift
+++ b/Tests/ParserCombinatorTests/ParserCombinator_TestCase.swift
@@ -64,11 +64,9 @@ class ParserCombinator_TestCase: XCTestCase {
 
 #if os(Linux)
     extension ParserCombinator_TestCase {
-        static var allTests : [(String, (ParserCombinator_TestCase) -> () throws -> Void)] {
-            return [
-                ("test_addition", test_addition),
-                ("test_readme_code", test_readme_code)
-            ]
-        }
+        static var allTests = [
+            ("test_addition", test_addition),
+            ("test_readme_code", test_readme_code)
+        ]
     }
 #endif

--- a/Tests/ParserCombinatorTests/ParserTests.swift
+++ b/Tests/ParserCombinatorTests/ParserTests.swift
@@ -89,16 +89,14 @@ class ParserTests: XCTestCase {
 
 #if os(Linux)
     extension ParserTests {
-        static var allTests : [(String, (ParserTests) -> () throws -> Void)] {
-            return [
-                ("test_unit", test_unit),
-                ("test_init_producesSuccess", test_init_producesSuccess),
-                ("test_init_producesFail", test_init_producesFail),
-                ("test_init", test_init),
-                ("test_flatMap_success", test_flatMap_success),
-                ("test_flatMap_fail", test_flatMap_fail),
-                ("test_map", test_map),
-            ]
-        }
+        static var allTests = [
+            ("test_unit", test_unit),
+            ("test_init_producesSuccess", test_init_producesSuccess),
+            ("test_init_producesFail", test_init_producesFail),
+            ("test_init", test_init),
+            ("test_flatMap_success", test_flatMap_success),
+            ("test_flatMap_fail", test_flatMap_fail),
+            ("test_map", test_map),
+        ]
     }
 #endif

--- a/Tests/ParserCombinatorTests/RegexParserTests.swift
+++ b/Tests/ParserCombinatorTests/RegexParserTests.swift
@@ -76,7 +76,6 @@ class RegexParserTests: XCTestCase {
                 ("test_parse_number", test_parse_number),
                 ("test_parse_lowercasedLetters", test_parse_lowercasedLetters),
                 ("test_parse_fail", test_parse_fail),
-                ("test_parse_fail_invalidRegex", test_parse_fail_invalidRegex),
                 ("test_error", test_error),
             ]
         }

--- a/Tests/ParserCombinatorTests/RegexParserTests.swift
+++ b/Tests/ParserCombinatorTests/RegexParserTests.swift
@@ -8,7 +8,6 @@
 import XCTest
 @testable import ParserCombinator
 
-#if os(OSX)
 class RegexParserTests: XCTestCase {
 
     func test_init() throws {
@@ -17,7 +16,7 @@ class RegexParserTests: XCTestCase {
         XCTAssertEqual(parser.regex, regex)
     }
 
-    func test_init_throw() {
+    func test_init_throw() throws {
         XCTAssertThrowsError(try RegexParser("\\"))
     }
     
@@ -60,4 +59,19 @@ class RegexParserTests: XCTestCase {
     }
     
 }
+
+#if os(Linux)
+    extension RegexParserTests {
+        static var allTests : [(String, (RegexParserTests) -> () throws -> Void)] {
+            return [
+                ("test_init", test_init),
+                ("test_init_throw", test_init_throw),
+                ("test_init_stringLiteral", test_init_stringLiteral),
+                ("test_parse_number", test_parse_number),
+                ("test_parse_lowercasedLetters", test_parse_lowercasedLetters),
+                ("test_parse_fail", test_parse_fail),
+                ("test_error", test_error),
+            ]
+        }
+    }
 #endif

--- a/Tests/ParserCombinatorTests/RegexParserTests.swift
+++ b/Tests/ParserCombinatorTests/RegexParserTests.swift
@@ -76,6 +76,7 @@ class RegexParserTests: XCTestCase {
                 ("test_parse_number", test_parse_number),
                 ("test_parse_lowercasedLetters", test_parse_lowercasedLetters),
                 ("test_parse_fail", test_parse_fail),
+//                ("test_parse_fail_invalidRegex", test_parse_fail_invalidRegex), // deactivated until https://bugs.swift.org/browse/SR-5477 is fixed
                 ("test_error", test_error),
             ]
         }

--- a/Tests/ParserCombinatorTests/RegexParserTests.swift
+++ b/Tests/ParserCombinatorTests/RegexParserTests.swift
@@ -69,16 +69,14 @@ class RegexParserTests: XCTestCase {
 
 #if os(Linux)
     extension RegexParserTests {
-        static var allTests : [(String, (RegexParserTests) -> () throws -> Void)] {
-            return [
-                ("test_init", test_init),
-                ("test_init_stringLiteral", test_init_stringLiteral),
-                ("test_parse_number", test_parse_number),
-                ("test_parse_lowercasedLetters", test_parse_lowercasedLetters),
-                ("test_parse_fail", test_parse_fail),
-//                ("test_parse_fail_invalidRegex", test_parse_fail_invalidRegex), // deactivated until https://bugs.swift.org/browse/SR-5477 is fixed
-                ("test_error", test_error),
-            ]
-        }
+        static var allTests = [
+            ("test_init", test_init),
+            ("test_init_stringLiteral", test_init_stringLiteral),
+            ("test_parse_number", test_parse_number),
+            ("test_parse_lowercasedLetters", test_parse_lowercasedLetters),
+            ("test_parse_fail", test_parse_fail),
+//            ("test_parse_fail_invalidRegex", test_parse_fail_invalidRegex), // deactivated until https://bugs.swift.org/browse/SR-5477 is fixed
+            ("test_error", test_error),
+        ]
     }
 #endif

--- a/Tests/ParserCombinatorTests/RegexParserTests.swift
+++ b/Tests/ParserCombinatorTests/RegexParserTests.swift
@@ -10,14 +10,10 @@ import XCTest
 
 class RegexParserTests: XCTestCase {
 
-    func test_init() throws {
+    func test_init() {
         let regex = "a"
-        let parser = try RegexParser(regex)
+        let parser = RegexParser(regex)
         XCTAssertEqual(parser.regex, regex)
-    }
-
-    func test_init_throw() throws {
-        XCTAssertThrowsError(try RegexParser("\\"))
     }
     
     func test_init_stringLiteral() {
@@ -26,7 +22,7 @@ class RegexParserTests: XCTestCase {
     }
     
     func test_parse_number() throws {
-        let parser = try RegexParser("[0-9]+") ^^ { r in Int(r)! }
+        let parser = RegexParser("[0-9]+") ^^ { r in Int(r)! }
         let result = parser.parse("1234")
         XCTAssertEqual(try result.unwrap(), 1234)
         
@@ -34,7 +30,7 @@ class RegexParserTests: XCTestCase {
     }
     
     func test_parse_lowercasedLetters() throws {
-        let parser = try RegexParser("[a-z]+")
+        let parser = RegexParser("[a-z]+")
         let result = parser.parse("abc")
         XCTAssertEqual(try result.unwrap(), "abc")
         
@@ -53,9 +49,20 @@ class RegexParserTests: XCTestCase {
         XCTAssertEqual(input, "a")
     }
     
+    func test_parse_fail_invalidRegex() throws {
+        let parser = "[".r
+        let result = parser.parse("abc")
+        let error = try result.error() as! RegexParser.Error
+        guard case let .invalidRegex(regex) = error else {
+            return XCTFail("Entered invalid regex, but got \(error) instead.")
+        }
+        XCTAssertEqual(regex, "[")
+    }
+    
     func test_error() {
         XCTAssertEqual(RegexParser.Error.doesNotMatch(pattern: "", input: "").code, 0)
         XCTAssertEqual(RegexParser.Error.unimplemented.code, 1)
+        XCTAssertEqual(RegexParser.Error.invalidRegex("").code, 2)
     }
     
 }
@@ -65,11 +72,11 @@ class RegexParserTests: XCTestCase {
         static var allTests : [(String, (RegexParserTests) -> () throws -> Void)] {
             return [
                 ("test_init", test_init),
-                ("test_init_throw", test_init_throw),
                 ("test_init_stringLiteral", test_init_stringLiteral),
                 ("test_parse_number", test_parse_number),
                 ("test_parse_lowercasedLetters", test_parse_lowercasedLetters),
                 ("test_parse_fail", test_parse_fail),
+                ("test_parse_fail_invalidRegex", test_parse_fail_invalidRegex),
                 ("test_error", test_error),
             ]
         }


### PR DESCRIPTION
* Introduce RegexParser to Linux as well (invalid regex crashes -> https://bugs.swift.org/browse/SR-5477)
* Added or method that takes a sequence
* Added generated file for SPM compatibility
* Added `make initial` step to podspec

Carthage is unfortunately not possible currently.